### PR TITLE
Changes single quotes to backticks in dkms-install.sh

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -7,7 +7,7 @@ else
   echo "About to run dkms install steps..."
 fi
 
-DRV_DIR='pwd'
+DRV_DIR=`pwd`
 DRV_NAME=rtl8812au
 DRV_VERSION=5.3.4
 


### PR DESCRIPTION
Changing from single quote ' to backtick ` allows the DRV_DIR variable to get the current working directory assigned.